### PR TITLE
Proxied the Analytics Script: Plausible

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
-module.exports = {
+const { withPlausibleProxy } = require('next-plausible')
+
+module.exports = withPlausibleProxy()({
   images: {
     domains: ['americodersbucket.s3.us-west-2.amazonaws.com']
   }
-}
+})


### PR DESCRIPTION
from https://github.com/4lejandrito/next-plausible: 

Proxy the Analytics Script
To avoid being blocked by adblockers plausible recommends proxying the script. To do this you need to wrap your next.config.js with the withPlausibleProxy function:

const { withPlausibleProxy } = require('next-plausible')

module.exports = withPlausibleProxy()({
  // ...your next js config, if any
})